### PR TITLE
Fix undefined name: inception_v3_preprocess_input

### DIFF
--- a/transfer/model.py
+++ b/transfer/model.py
@@ -42,7 +42,7 @@ def gen_minibatches(array_dir, array_names, batch_size, architecture, final = Fa
                 elif architecture == 'xception':
                     array = np.squeeze(xception_preprocess_input(array[np.newaxis].astype(np.float32)))
                 else:
-                    array = np.squeeze(inception_v3_preprocess_input(array[np.newaxis].astype(np.float32)))
+                    array = np.squeeze(vgg_preprocess_input(array[np.newaxis].astype(np.float32)))
 
             arrays.append(array)
             labels.append(np.load(img_path.replace('-img-','-label-')))
@@ -244,7 +244,7 @@ def train_model(project, final = False, last = False):
                     elif project['architecture'] == 'xception':
                         img = np.squeeze(xception_preprocess_input(img[np.newaxis].astype(np.float32)))
                     else:
-                        img = np.squeeze(inception_v3_preprocess_input(img[np.newaxis].astype(np.float32)))
+                        img = np.squeeze(vgg_preprocess_input(img[np.newaxis].astype(np.float32)))
                 prediction = model.predict(img[np.newaxis])
                 best_predictions.append(project['categories'][np.argmax(prediction)])
                 true_label = np.load(img_path.replace('-img-','-label-'))


### PR DESCRIPTION
flake8 testing of https://github.com/matthew-sochor/transfer

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./transfer/model.py:45:40: F821 undefined name 'inception_v3_preprocess_input'
                    array = np.squeeze(inception_v3_preprocess_input(array[np.newaxis].astype(np.float32)))
                                       ^
./transfer/model.py:247:42: F821 undefined name 'inception_v3_preprocess_input'
                        img = np.squeeze(inception_v3_preprocess_input(img[np.newaxis].astype(np.float32)))
                                         ^
2     F821 undefined name 'inception_v3_preprocess_input'
```